### PR TITLE
Add crypto sales dataset and retrieval helper

### DIFF
--- a/data.py
+++ b/data.py
@@ -51,6 +51,39 @@ crypto_jvm = {
                    }                                                                         ,
 }
 
+crypto_sales = {
+    'COMPRA_001': {
+        'Data'     : datetime.strptime("2025-04-30 12:00:00", "%Y-%m-%d %H:%M:%S"),
+        'Reais'    : 1159.53,
+        'Bitcoin'  : 0.00165647,
+        'Preço BTC': 700000.0,
+    },
+    'COMPRA_002': {
+        'Data'     : datetime.strptime("2025-05-15 12:00:00", "%Y-%m-%d %H:%M:%S"),
+        'Reais'    : 1039.71,
+        'Bitcoin'  : 0.00159955,
+        'Preço BTC': 650000.0,
+    },
+    'COMPRA_003': {
+        'Data'     : datetime.strptime("2025-05-20 12:00:00", "%Y-%m-%d %H:%M:%S"),
+        'Reais'    : 1222.27,
+        'Bitcoin'  : 0.00179745,
+        'Preço BTC': 680000.0,
+    },
+    'COMPRA_004': {
+        'Data'     : datetime.strptime("2025-05-25 12:00:00", "%Y-%m-%d %H:%M:%S"),
+        'Reais'    : 1081.87,
+        'Bitcoin'  : 0.00180312,
+        'Preço BTC': 600000.0,
+    },
+    'COMPRA_005': {
+        'Data'     : datetime.strptime("2025-06-01 12:00:00", "%Y-%m-%d %H:%M:%S"),
+        'Reais'    : 1144.17,
+        'Bitcoin'  : 0.00208031,
+        'Preço BTC': 550000.0,
+    },
+}
+
 crypto_reference_sim = {
     'REF_001    ': {'Data'    : datetime.strptime("2025-02-20 19:45:31", "%Y-%m-%d %H:%M:%S"),
                    'CDI'      : 1.01                                                         ,
@@ -92,3 +125,17 @@ crypto_sim = {
                    'Preço BTC': 707.0                                                        ,
                    }                                                                         ,
 }
+
+
+def get_sale_info(purchase_id: str):
+    """Retrieve sale information for a given purchase ID.
+
+    Args:
+        purchase_id: Identifier of the purchase (e.g., "COMPRA_001").
+
+    Returns:
+        A dictionary with sale details or None if the purchase ID was not sold.
+    """
+
+    return crypto_sales.get(purchase_id)
+


### PR DESCRIPTION
## Summary
- add `crypto_sales` dictionary containing sale date, reais, quantity and sale price keyed by purchase ID
- implement `get_sale_info` helper to fetch sale details for a purchase

## Testing
- `python -m py_compile data.py`
- `python - <<'PY'
from data import get_sale_info
print(get_sale_info('COMPRA_001'))
print(get_sale_info('COMPRA_999'))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68bde2e71e3c83309ff1a4bf1d955b16