### PR TITLE
Add optional sales tracking to portfolio builder

### DIFF
--- a/run.py
+++ b/run.py
@@ -5,19 +5,31 @@ B3_REF             = 135298.98
 
 from body import *
 
-portfolio = build_portfolio(crypto_reference = crypto_reference, crypto_purchases = crypto_purchases, asset = "B3")
-appreciation_per_date_b3, weighted_b3 = calculate_appreciation_index(portfolio = portfolio, today_index_value = B3_REF)
+portfolio = build_portfolio(crypto_reference=crypto_reference,
+                            crypto_purchases=crypto_purchases,
+                            asset="B3")
+appreciation_per_date_b3, weighted_b3 = calculate_appreciation_index(
+    portfolio=portfolio, today_index_value=B3_REF)
 print("B3:")
 print_appreciation_table(appreciation_per_date_b3, weighted_b3)
 
-portfolio_cdi = build_portfolio(crypto_reference = crypto_reference, crypto_purchases = crypto_purchases, asset = "CDI")
-appreciation_per_date_cdi, weighted_cdi = calculate_appreciation_index(portfolio = portfolio_cdi, today_index_value = CDI_REF)
+portfolio_cdi = build_portfolio(crypto_reference=crypto_reference,
+                                crypto_purchases=crypto_purchases,
+                                asset="CDI")
+appreciation_per_date_cdi, weighted_cdi = calculate_appreciation_index(
+    portfolio=portfolio_cdi, today_index_value=CDI_REF)
 print("CDI:")
 print_appreciation_table(appreciation_per_date_cdi, weighted_cdi)
 
-portfolio_bitcoin = build_portfolio(crypto_reference = crypto_purchases, crypto_purchases = crypto_purchases, asset = "Bitcoin")
-appreciation_per_date_btc, weighted_btc = calculate_appreciation_asset(portfolio = portfolio_bitcoin, today_asset_value = BRL_POR_BTC_REF)
+# Include realized sale information for the crypto portfolio
+portfolio_bitcoin = build_portfolio(crypto_reference=crypto_purchases,
+                                    crypto_purchases=crypto_purchases,
+                                    asset="Bitcoin",
+                                    crypto_sales=crypto_sales)
+appreciation_per_date_btc, weighted_btc = calculate_appreciation_asset(
+    portfolio=portfolio_bitcoin, today_asset_value=BRL_POR_BTC_REF)
 print("Bitcoin:")
 print_appreciation_table(appreciation_per_date_btc, weighted_btc)
 
-plot_bar_chart(appreciation_per_date_btc, [weighted_btc, weighted_b3, 1.5*(weighted_b3-1)+1, 2*(weighted_b3-1)+1])
+plot_bar_chart(appreciation_per_date_btc,
+               [weighted_btc, weighted_b3, 1.5*(weighted_b3-1)+1, 2*(weighted_b3-1)+1])


### PR DESCRIPTION
## Summary
- extend `build_portfolio` to accept optional `crypto_sales` and record sale date and price
- update appreciation helpers and run script to handle new portfolio entry structure

## Testing
- `python run.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `pip install matplotlib` *(fails: Could not find a version that satisfies the requirement matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf1d7a9148330b01da4b56ee4ea2a