### PR TITLE
Handle asset lookup in build_portfolio when absent from reference data

### DIFF
--- a/body.py
+++ b/body.py
@@ -21,15 +21,25 @@ def build_portfolio(crypto_reference, crypto_purchases, asset, crypto_sales=None
         ``[reais_buy, asset_buy_value, sale_date, sale_price]`` as value. ``sale_date`` and
         ``sale_price`` will be ``None`` when no matching sale is found.
     """
-    # Create a mapping of dates to asset values
-    date_to_asset = {entry["Data"]: entry[asset] for entry in crypto_reference.values()}
+    # Create a mapping of dates to asset values from the reference dataset when
+    # the requested ``asset`` key exists there. Otherwise, the asset value will
+    # be pulled directly from the purchase entry.
+    date_to_asset = {
+        entry["Data"]: entry.get(asset)
+        for entry in crypto_reference.values()
+        if asset in entry
+    }
 
     # Build portfolio dictionary
     portfolio = {}
     for purchase_id, entry in crypto_purchases.items():
         date = entry["Data"]
         reais = entry["Reais"]
-        asset_value = date_to_asset.get(date, None)  # Get asset points/amount for the same date
+        # Prefer the asset value from the purchase entry when available;
+        # fall back to the reference dataset otherwise.
+        asset_value = entry.get(asset)
+        if asset_value is None:
+            asset_value = date_to_asset.get(date)
 
         sale_date = None
         sale_price = None


### PR DESCRIPTION
## Summary
- Avoid KeyError in `build_portfolio` when requested asset isn't present in reference data
- Allow portfolio builder to use asset values from purchase records if needed

## Testing
- `python -m py_compile body.py`
- `MPLBACKEND=Agg python run.py` *(fails: ModuleNotFoundError: No module named 'matplotlib')*
- `pip install matplotlib` *(fails: Could not find a version that satisfies the requirement matplotlib)*

------
https://chatgpt.com/codex/tasks/task_e_68bddd0804bc8330abbe777cf24e698e