### PR TITLE
Allocate sales across purchase lots, cheapest-cost-basis first

### DIFF
--- a/body.py
+++ b/body.py
@@ -6,227 +6,317 @@ from data import *
 crypto_reference = crypto_reference_jvm
 crypto_purchases = crypto_jvm
 
-def build_portfolio(crypto_reference, crypto_purchases, asset, crypto_sales=None):
-    """Build a portfolio dictionary from purchase and optional sale data.
+_EPS_BTC = 1e-12
 
-    Args:
-        crypto_reference: Dictionary mapping reference IDs to asset values and dates.
-        crypto_purchases: Dictionary mapping purchase IDs to amounts in Reais and purchase dates.
-        asset: Key within the reference dictionaries representing the asset value to track
-               (e.g. "B3", "CDI", "Bitcoin").
-        crypto_sales: Optional dictionary mapping purchase IDs to sale information.
+
+def allocate_sales(crypto_purchases, crypto_sales=None, verbose=False):
+    """Match sales against purchase lots, cheapest-cost-basis-first.
+
+    For each sale (processed in chronological order) the BTC quantity is
+    consumed from purchase lots whose ``Data`` is on or before the sale date,
+    selecting lots in ascending ``Preço BTC`` (ties broken by oldest purchase
+    date). Sales must specify ``Reais`` and ``Preço BTC``; the BTC quantity is
+    derived as ``Reais / Preço BTC``.
+
+    Raises:
+        ValueError: when the total BTC requested by sales exceeds what is
+            available from eligible purchase lots.
 
     Returns:
-        Dictionary with purchase date (``YYYY-MM-DD``) as key and
-        ``[reais_buy, asset_buy_value, sale_date, sale_price]`` as value. ``sale_date`` and
-        ``sale_price`` will be ``None`` when no matching sale is found.
+        Tuple ``(lots, allocations)`` where:
+            - ``lots`` is ``{purchase_id: remaining_btc}``.
+            - ``allocations`` is a list of dicts, in execution order:
+              ``{sale_id, sale_date, sale_datetime, sale_price,
+                 purchase_id, purchase_date, purchase_datetime,
+                 buy_price, btc_consumed}``.
     """
-    # Create a mapping of dates to asset values from the reference dataset when
-    # the requested ``asset`` key exists there. Otherwise, the asset value will
-    # be pulled directly from the purchase entry.
+    sales = crypto_sales or {}
+
+    lots = {}
+    for purchase_id, entry in crypto_purchases.items():
+        btc = entry.get("Bitcoin")
+        if btc is None:
+            continue
+        lots[purchase_id] = btc
+
+    allocations = []
+    if verbose:
+        print("Alocação de vendas (mais barato primeiro):")
+        header = (f"  {'Venda':<10} {'Compra':<10} {'BTC consumido':>14} "
+                  f"{'Preço compra':>14} {'Preço venda':>14} {'Retorno':>10}")
+        print(header)
+        print("  " + "-" * (len(header) - 2))
+
+    sorted_sales = sorted(sales.items(), key=lambda kv: kv[1]["Data"])
+    for sale_id, sale in sorted_sales:
+        sale_price = sale["Preço BTC"]
+        btc_to_consume = sale["Reais"] / sale_price
+        sale_datetime = sale["Data"]
+        sale_date = sale_datetime.strftime("%Y-%m-%d")
+
+        eligible = []
+        for purchase_id, remaining in lots.items():
+            if remaining <= _EPS_BTC:
+                continue
+            entry = crypto_purchases[purchase_id]
+            if entry["Data"] > sale_datetime:
+                continue
+            eligible.append((entry["Preço BTC"], entry["Data"], purchase_id))
+        eligible.sort()
+
+        for buy_price, purchase_datetime, purchase_id in eligible:
+            if btc_to_consume <= _EPS_BTC:
+                break
+            remaining = lots[purchase_id]
+            take = min(remaining, btc_to_consume)
+            lots[purchase_id] = remaining - take
+            if lots[purchase_id] < _EPS_BTC:
+                lots[purchase_id] = 0.0
+            btc_to_consume -= take
+
+            allocation = {
+                "sale_id": sale_id,
+                "sale_date": sale_date,
+                "sale_datetime": sale_datetime,
+                "sale_price": sale_price,
+                "purchase_id": purchase_id,
+                "purchase_date": purchase_datetime.strftime("%Y-%m-%d"),
+                "purchase_datetime": purchase_datetime,
+                "buy_price": buy_price,
+                "btc_consumed": take,
+            }
+            allocations.append(allocation)
+
+            if verbose:
+                ret = sale_price / buy_price
+                print(f"  {sale_id:<10} {purchase_id:<10} "
+                      f"{take:>14.8f} {buy_price:>14.2f} "
+                      f"{sale_price:>14.2f} {ret:>10.4f}")
+
+        if btc_to_consume > _EPS_BTC:
+            raise ValueError(
+                f"Sale {sale_id} requires {sale['Reais'] / sale_price:.8f} BTC "
+                f"but only {sale['Reais'] / sale_price - btc_to_consume:.8f} BTC "
+                f"could be allocated from eligible lots (shortfall "
+                f"{btc_to_consume:.8f} BTC)."
+            )
+
+    if verbose:
+        print()
+    return lots, allocations
+
+
+def build_portfolio(crypto_reference, crypto_purchases, asset, crypto_sales=None):
+    """Build a per-purchase portfolio record enriched with sale allocations.
+
+    Args:
+        crypto_reference: Reference dataset (date → index/asset values).
+        crypto_purchases: Purchases keyed by COMPRA_ ID.
+        asset: ``"B3"``, ``"CDI"`` or ``"Bitcoin"``.
+        crypto_sales: Optional sales dict keyed by VENDA_ ID.
+
+    Returns:
+        Dictionary keyed by purchase_id with rich records::
+
+            {
+                'purchase_date':     str (YYYY-MM-DD),
+                'purchase_datetime': datetime,
+                'reais':             float,
+                'asset_value':       float,  # index level or BTC price at buy
+                'btc_at_purchase':   float or None,
+                'remaining_btc':     float,
+                'allocations':       [ {sale_id, sale_date, sale_price,
+                                        btc_consumed, buy_price}, ... ],
+            }
+
+        Purchases without a usable ``asset_value`` for the requested asset are
+        skipped.
+    """
     date_to_asset = {
         entry["Data"]: entry.get(asset)
         for entry in crypto_reference.values()
         if asset in entry
     }
 
-    # Build portfolio dictionary
+    lots, allocations = allocate_sales(crypto_purchases, crypto_sales)
+
+    allocs_by_purchase = {}
+    for alloc in allocations:
+        allocs_by_purchase.setdefault(alloc["purchase_id"], []).append(alloc)
+
     portfolio = {}
     for purchase_id, entry in crypto_purchases.items():
-        date = entry["Data"]
-        reais = entry["Reais"]
-        # Prefer the asset value from the purchase entry when available;
-        # fall back to the reference dataset otherwise.
         asset_value = entry.get(asset)
         if asset_value is None:
-            asset_value = date_to_asset.get(date)
+            asset_value = date_to_asset.get(entry["Data"])
+        if asset_value is None:
+            continue
 
-        sale_date = None
-        sale_price = None
-        if crypto_sales is not None:
-            sale_entry = crypto_sales.get(purchase_id)
-            if sale_entry:
-                sale_date = sale_entry["Data"].strftime("%Y-%m-%d")
-                sale_price = sale_entry.get("Reais")
-
-        if asset_value is not None:  # Ensure there's a valid asset value
-            portfolio[date.strftime("%Y-%m-%d")] = [reais, asset_value, sale_date, sale_price]
+        portfolio[purchase_id] = {
+            "purchase_date":     entry["Data"].strftime("%Y-%m-%d"),
+            "purchase_datetime": entry["Data"],
+            "reais":             entry["Reais"],
+            "asset_value":       asset_value,
+            "btc_at_purchase":   entry.get("Bitcoin"),
+            "remaining_btc":     lots.get(purchase_id, 0.0),
+            "allocations":       allocs_by_purchase.get(purchase_id, []),
+        }
 
     return portfolio
 
-def calculate_appreciation_asset(portfolio, today_asset_value):
-    """Calculate asset appreciation.
 
-    Calculates:
-      - Asset appreciation per date.
-      - Total weighted asset appreciation using investment amounts as weights.
-        Sold investments contribute their realized ``sale_price`` appreciation;
-        unsold investments use the current ``today_asset_value``.
+def _slice_brl_in(purchase, btc_amount):
+    """BRL invested in a sub-slice of a purchase lot."""
+    btc_total = purchase["btc_at_purchase"]
+    if btc_total and btc_total > 0:
+        return purchase["reais"] * (btc_amount / btc_total)
+    # Fallback: pro-rate equally if BTC info is missing (shouldn't happen for crypto_jvm).
+    return purchase["reais"]
 
-    Args:
-        portfolio: Dictionary where keys are dates (``YYYY-MM-DD``) and values are
-            ``[purchase_price, asset_value_at_purchase, sale_date, sale_price]``.
-        today_asset_value: Current asset value in Reais.
 
-    Returns:
-        Tuple containing:
-            - Dictionary with asset appreciation per date.
-            - Total weighted asset appreciation (percentage). Returns ``0`` when
-              the portfolio is empty.
+def _appreciation_rows(portfolio, today_value):
+    """Build per-allocation appreciation rows shared by asset & index variants.
+
+    For each purchase, emits one row per sale allocation plus (if any BTC
+    remains) one row for the unsold remainder. Preserves the legacy
+    ``today_value / brl_invested`` formula for unsold slices.
+
+    Returns ``(rows, weighted)`` where ``rows`` maps a label to an appreciation
+    factor and ``weighted`` is the BRL-weighted average across all rows.
     """
-    appreciation_per_date = {}
+    rows = {}
     weighted_sum = 0
     total_investment = 0
 
-    for date, (purchase_price, _asset_value, sale_date, sale_price) in portfolio.items():
-        if sale_price is not None:
-            appreciation = sale_price / purchase_price
-        else:
-            appreciation = today_asset_value / purchase_price
+    for purchase_id, p in portfolio.items():
+        for alloc in p["allocations"]:
+            brl_in = _slice_brl_in(p, alloc["btc_consumed"])
+            appreciation = alloc["sale_price"] / alloc["buy_price"]
+            label = f"{purchase_id}→{alloc['sale_id']}"
+            rows[label] = appreciation
+            weighted_sum += brl_in * appreciation
+            total_investment += brl_in
 
-        weighted_sum += purchase_price * appreciation
-        total_investment += purchase_price
-        appreciation_per_date[date] = appreciation
+        remaining = p["remaining_btc"]
+        if remaining and remaining > _EPS_BTC and p["btc_at_purchase"]:
+            brl_in = _slice_brl_in(p, remaining)
+            appreciation = today_value / brl_in
+            label = f"{purchase_id} (unsold)"
+            rows[label] = appreciation
+            weighted_sum += brl_in * appreciation
+            total_investment += brl_in
 
-    weighted_appreciation = (
-        weighted_sum / total_investment if total_investment else 0
-    )
+    weighted = weighted_sum / total_investment if total_investment else 0
+    return rows, weighted
 
-    return appreciation_per_date, weighted_appreciation
+
+def calculate_appreciation_asset(portfolio, today_asset_value):
+    """Per-allocation Bitcoin appreciation rows + BRL-weighted average."""
+    return _appreciation_rows(portfolio, today_asset_value)
+
+
+def calculate_appreciation_index(portfolio, today_index_value):
+    """Per-allocation B3/CDI appreciation rows + BRL-weighted average."""
+    return _appreciation_rows(portfolio, today_index_value)
+
 
 def weighted_unsold_btc_price(crypto_purchases, crypto_sales=None, verbose=False):
-    """Weighted-average BTC buy price across unsold positions.
+    """Weighted-average BTC buy price across remaining (unsold) BTC.
 
-    Σ(bitcoin_i × price_i) / Σ(bitcoin_i), restricted to purchases without a
-    matching entry in ``crypto_sales``.
-
-    Returns ``0`` when there are no unsold positions. When ``verbose`` is true,
-    prints each purchase that was considered or discarded and the running
-    numerator/denominator of the weighted average.
+    Weights each purchase lot by its ``remaining_btc`` after the sale-allocation
+    pass. Partially-sold lots contribute only their leftover amount.
     """
-    sales = crypto_sales or {}
+    lots, _allocs = allocate_sales(crypto_purchases, crypto_sales)
     total_btc = 0
     weighted_sum = 0
     if verbose:
-        print("Cálculo do preço médio ponderado (não vendidos):")
-        header = (f"  {'ID':<12} {'BTC':>12} {'Preço BTC':>14} "
-                  f"{'BTC × Preço':>14} {'Reais':>10} {'Status':<24}")
+        print("Cálculo do preço médio ponderado (BTC remanescente):")
+        header = (f"  {'ID':<12} {'BTC restante':>14} {'Preço BTC':>14} "
+                  f"{'BTC × Preço':>14} {'Reais (lote)':>14} {'Status':<28}")
         print(header)
         print("  " + "-" * (len(header) - 2))
+
     for purchase_id, entry in crypto_purchases.items():
-        btc = entry.get("Bitcoin")
+        btc_total = entry.get("Bitcoin")
         price = entry.get("Preço BTC")
         reais = entry.get("Reais")
-        if purchase_id in sales:
-            status = "descartado (vendido)"
-            included = False
-        elif btc is None or price is None:
+        remaining = lots.get(purchase_id, 0.0)
+
+        if btc_total is None or price is None:
             status = "descartado (dados ausentes)"
             included = False
+        elif remaining <= _EPS_BTC:
+            status = "descartado (totalmente vendido)"
+            included = False
+        elif remaining < btc_total - _EPS_BTC:
+            status = "considerado (parcial)"
+            included = True
         else:
             status = "considerado"
             included = True
 
         if verbose:
-            btc_str = f"{btc:.8f}" if btc is not None else "—"
+            btc_str = f"{remaining:.8f}" if btc_total is not None else "—"
             price_str = f"{price:.2f}" if price is not None else "—"
-            product_str = f"{btc * price:.2f}" if btc is not None and price is not None else "—"
+            product_str = (f"{remaining * price:.2f}"
+                           if price is not None and btc_total is not None else "—")
             reais_str = f"{reais:.2f}" if reais is not None else "—"
-            print(f"  {purchase_id:<12} {btc_str:>12} {price_str:>14} "
-                  f"{product_str:>14} {reais_str:>10} {status:<24}")
+            print(f"  {purchase_id:<12} {btc_str:>14} {price_str:>14} "
+                  f"{product_str:>14} {reais_str:>14} {status:<28}")
 
         if included:
-            weighted_sum += btc * price
-            total_btc += btc
+            weighted_sum += remaining * price
+            total_btc += remaining
 
     avg = weighted_sum / total_btc if total_btc else 0
     if verbose:
-        print(f"  Σ(BTC × Preço) = {weighted_sum:.2f} BRL")
+        print(f"  Σ(BTC × Preço) = {weighted_sum:.6f} BRL")
         print(f"  Σ(BTC)         = {total_btc:.8f} BTC")
         print(f"  Média ponderada = {avg:.2f} BRL/BTC\n")
     return avg
 
-def calculate_appreciation_index(portfolio, today_index_value):
-    """Calculate index appreciation.
 
-    Calculates:
-      - Index appreciation per date.
-      - Total weighted index appreciation using investment amounts as weights.
-        Sold investments contribute their realized ``sale_price`` appreciation;
-        unsold investments use the current ``today_index_value``.
+def print_appreciation_table(appreciation_per_label, weighted_average):
+    """Prints appreciation data in a tabular format with aligned columns.
 
-    Args:
-        portfolio: Dictionary where keys are dates (``YYYY-MM-DD``) and values are
-            ``[purchase_price, index_points_at_purchase, sale_date, sale_price]``.
-        today_index_value: Current index quotation in Reais.
-
-    Returns:
-        Tuple containing:
-            - Dictionary with index appreciation per date.
-            - Total weighted index appreciation (percentage). Returns ``0`` when
-              the portfolio is empty.
-    """
-    appreciation_per_date = {}
-    weighted_sum = 0
-    total_investment = 0
-
-    for date, (purchase_price, _index_value, sale_date, sale_price) in portfolio.items():
-        if sale_price is not None:
-            appreciation = sale_price / purchase_price
-        else:
-            appreciation = today_index_value / purchase_price
-
-        weighted_sum += purchase_price * appreciation
-        total_investment += purchase_price
-        appreciation_per_date[date] = appreciation
-
-    weighted_appreciation = (
-        weighted_sum / total_investment if total_investment else 0
-    )
-
-    return appreciation_per_date, weighted_appreciation
-
-def print_appreciation_table(appreciation_per_date, weighted_average):
-    """
-    Prints appreciation data in a tabular format with aligned columns.
     The weighted appreciation is shown only in the last row.
-    
-    :param appreciation_per_date: Dictionary {date: appreciation value}
+
+    :param appreciation_per_label: Dictionary {label: appreciation value}
     :param weighted_average: Total weighted appreciation value
     """
-    # Define column widths
-    DATE_WIDTH = 15
+    LABEL_WIDTH = 26
     APPRECIATION_WIDTH = 14
     WEIGHTED_WIDTH = 26
-    col_widths = {"date": DATE_WIDTH, "appreciation": APPRECIATION_WIDTH, "weighted": WEIGHTED_WIDTH}
+    col_widths = {"label": LABEL_WIDTH, "appreciation": APPRECIATION_WIDTH, "weighted": WEIGHTED_WIDTH}
 
-    # Print header
-    print(f"{'Data':<{col_widths['date']}} {'Apreciação':<{col_widths['appreciation']}} {'Apreciação Ponderada':<{col_widths['weighted']}}")
-    print("-" * (sum(col_widths.values()) + 2))  # Table separator
+    print(f"{'Alocação':<{col_widths['label']}} "
+          f"{'Apreciação':<{col_widths['appreciation']}} "
+          f"{'Apreciação Ponderada':<{col_widths['weighted']}}")
+    print("-" * (sum(col_widths.values()) + 2))
 
-    # Print each row
-    for idx, (date, appreciation) in enumerate(appreciation_per_date.items()):
-        weighted_str = f"{weighted_average:.2f}" if idx == len(appreciation_per_date) - 1 else ""  # Show weighted only in last row
-        print(f"{date:<{col_widths['date']}} {appreciation:<{col_widths['appreciation']}.2f} {weighted_str:<{col_widths['weighted']}}")
-    
+    items = list(appreciation_per_label.items())
+    for idx, (label, appreciation) in enumerate(items):
+        weighted_str = f"{weighted_average:.2f}" if idx == len(items) - 1 else ""
+        print(f"{label:<{col_widths['label']}} "
+              f"{appreciation:<{col_widths['appreciation']}.2f} "
+              f"{weighted_str:<{col_widths['weighted']}}")
+
     print("\n")
 
 
 def plot_bar_chart(data_dict, ref_list):
     """
     Plots a bar chart using values from a dictionary.
-    
+
     :param data_dict: Dictionary where keys are labels and values are numerical data.
-    :param ref_value1: A float representing the first reference line.
-    :param ref_value2: A float representing the second reference line.
+    :param ref_list: List of reference-line values.
     """
     labels = list(data_dict.keys())
     values = list(data_dict.values())
 
-    plt.figure(figsize=(10, 5))  # Set figure size
+    plt.figure(figsize=(10, 5))
     plt.bar(labels, values, color="skyblue", edgecolor="black")
 
-    # Add reference lines
     plt.axhline(ref_list[0], color="red", linestyle="dashed", label=f"Ref 1: {ref_list[0]}")
     cores = ["red", "orange", "green", "blue", "purple"]
     if len(cores) < len(ref_list):
@@ -234,14 +324,11 @@ def plot_bar_chart(data_dict, ref_list):
     for i, ref in enumerate(ref_list[1:], start=1):
         plt.axhline(ref, color=cores[i], linestyle="dashed", label=f"Ref {i}: {ref}")
 
-
-    # Labels and Title
     plt.xlabel("Categories")
     plt.ylabel("Values")
     plt.title("Bar Chart with Reference Lines")
     plt.legend()
-    
-    # Rotate x labels for better visibility if needed
+
     plt.xticks(rotation=45)
 
     plt.show()

--- a/data.py
+++ b/data.py
@@ -77,34 +77,9 @@ crypto_jvm = {
 }
 
 crypto_sales = {
-    'COMPRA_001': {
-        'Data'     : datetime.strptime("2025-04-30 12:00:00", "%Y-%m-%d %H:%M:%S"),
-        'Reais'    : 1159.53,
-        'Bitcoin'  : 0.00165647,
-        'Preço BTC': 700000.0,
-    },
-    'COMPRA_002': {
-        'Data'     : datetime.strptime("2025-05-15 12:00:00", "%Y-%m-%d %H:%M:%S"),
-        'Reais'    : 1039.71,
-        'Bitcoin'  : 0.00159955,
-        'Preço BTC': 650000.0,
-    },
-    'COMPRA_003': {
-        'Data'     : datetime.strptime("2025-05-20 12:00:00", "%Y-%m-%d %H:%M:%S"),
-        'Reais'    : 1222.27,
-        'Bitcoin'  : 0.00179745,
-        'Preço BTC': 680000.0,
-    },
-    'COMPRA_004': {
-        'Data'     : datetime.strptime("2025-05-25 12:00:00", "%Y-%m-%d %H:%M:%S"),
-        'Reais'    : 1081.87,
-        'Bitcoin'  : 0.00180312,
-        'Preço BTC': 600000.0,
-    },
-    'COMPRA_005': {
-        'Data'     : datetime.strptime("2025-06-01 12:00:00", "%Y-%m-%d %H:%M:%S"),
-        'Reais'    : 1144.17,
-        'Bitcoin'  : 0.00208031,
+    'VENDA_001': {
+        'Data'     : datetime.strptime("2025-03-30 12:00:00", "%Y-%m-%d %H:%M:%S"),
+        'Reais'    : 800.0,
         'Preço BTC': 550000.0,
     },
 }

--- a/run.py
+++ b/run.py
@@ -37,6 +37,9 @@ def parse_args():
     parser.add_argument("--verbose-avg", action="store_true",
                         help="Show the per-entry breakdown of the unsold-BTC "
                              "weighted-average price calculation.")
+    parser.add_argument("--verbose-alloc", action="store_true",
+                        help="Show the sale → purchase-lot allocation table "
+                             "(cheapest-cost-basis-first).")
     return parser.parse_args()
 
 
@@ -49,6 +52,9 @@ def selected_assets(asset_args):
 def main():
     args = parse_args()
     assets = selected_assets(args.asset)
+
+    if args.verbose_alloc:
+        allocate_sales(crypto_purchases, crypto_sales, verbose=True)
 
     weighted_b3 = None
     appreciation_per_date_btc = None


### PR DESCRIPTION
Sales are now independent events (keyed VENDA_*) with Reais and Preço BTC as the source of truth; BTC consumed = Reais / Preço BTC. A new allocate_sales walks sales chronologically and consumes BTC from eligible purchase lots (purchase_date <= sale_date, remaining
> 0), sorted by buy price ascending then purchase date ascending.
Over-sale raises a hard ValueError.

build_portfolio now returns rich per-purchase records carrying the list of allocations against each lot and the remaining BTC. calculate_appreciation_asset / _index emit one row per allocation plus one for the unsold remainder, keyed COMPRA_x→VENDA_y or "COMPRA_x (unsold)". weighted_unsold_btc_price now weights by remaining BTC so partially-sold lots still contribute their leftover.

Seeds crypto_sales with a single VENDA_001 (800 BRL on 2025-03-30 at 550000 BRL/BTC). Adds --verbose-alloc to dump the allocation table.

https://claude.ai/code/session_01Db2GrFhNvcFMUy5FBdqbTP